### PR TITLE
Add additional options to disk_device template

### DIFF
--- a/resources/disk_device.rb
+++ b/resources/disk_device.rb
@@ -5,9 +5,11 @@ def initialize(*args)
   @action = :attach
 end
 
-attribute :type,   :kind_of => String, :default => 'block'
-attribute :bus,    :kind_of => String, :default => 'virtio'
-attribute :source, :kind_of => String
-attribute :target, :kind_of => String, :name_attribute => true
-attribute :domain, :kind_of => String
-attribute :uri,    :kind_of => String, :default => 'qemu:///system'
+attribute :type,          :kind_of => String, :default => 'block'
+attribute :driver,        :kind_of => String, :default => 'raw'
+attribute :bus,           :kind_of => String, :default => 'virtio'
+attribute :source_device, :kind_of => String, :default => 'file'
+attribute :source,        :kind_of => String
+attribute :target,        :kind_of => String, :name_attribute => true
+attribute :domain,        :kind_of => String
+attribute :uri,           :kind_of => String, :default => 'qemu:///system'

--- a/templates/default/disk_device.xml
+++ b/templates/default/disk_device.xml
@@ -1,6 +1,6 @@
 <disk type='<%= @type %>' device='disk'>
-  <driver name='qemu'/>
-  <source dev='<%= @source %>'/>
+  <driver name='qemu' type='<%= @driver %>'/>
+  <source <%= @source_device %>= '<%= @source %>'/>
   <target dev='<%= @target %>' bus='<%= @bus %>'/>
 </disk>
 


### PR DESCRIPTION
Some additional disk_device template options to, among other things, allow definitions from a source file.
